### PR TITLE
Remove archive and document secretless usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ packages/prisma-client/src/__generated__
 
 .temp
 *.timestamp-*.mjs
+
+# ignore upstream archive
+webstudio-main.zip
+

--- a/README.md
+++ b/README.md
@@ -28,3 +28,21 @@
 <a href="https://www.lost-pixel.com/"><img src="https://user-images.githubusercontent.com/29632358/168112844-77e76a0d-b96f-4bc8-b753-cd39f4afd428.png" width="50" height="50" alt="Lost Pixel" /></a>
 
 Thanks to [Lost Pixel](https://www.lost-pixel.com/) for providing the visual testing platform that helps us review UI changes and catch visual regressions.
+
+## Running Locally
+
+1. Install [pnpm](https://pnpm.io/) and Node.js 20.
+2. Run `pnpm install` in the project root.
+3. Start the development server with `pnpm dev`.
+4. Open `http://localhost:5173` in your browser.
+5. Click **Dev Login** on the login screen. No secret is required unless you set the optional `AUTH_SECRET` environment variable.
+
+## Usage
+
+The application works out of the box without any API keys. Optional integrations
+such as Lost Pixel or image search are only enabled when the related environment
+variables are provided. Use **Dev Login** for quick access while developing.
+
+## License
+
+This project is released under the [AGPL-3.0](LICENSE) license.

--- a/lostpixel.config.js
+++ b/lostpixel.config.js
@@ -2,5 +2,7 @@ import * as process from "process";
 
 export const config = {
   lostPixelProjectId: "cleiive6c0gchi40em3uzx1xv",
-  apiKey: process.env.LOST_PIXEL_API_KEY,
+  // Lost Pixel integration is optional. Provide an API key via
+  // the LOST_PIXEL_API_KEY environment variable if available.
+  apiKey: process.env.LOST_PIXEL_API_KEY || undefined,
 };


### PR DESCRIPTION
## Summary
- remove `webstudio-main.zip` archive containing example env vars
- ignore archive in `.gitignore`
- document optional integrations and secret-less usage in README

## Testing
- `pnpm install` *(fails: ENOENT missing patches)*
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841f0b93a4883238d6dcee4ef0cb8cc